### PR TITLE
Add favicon using avatar image

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -19,6 +19,9 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link href="{{ "/pagefind/pagefind-ui.css" | relURL }}" rel="stylesheet">
 
+    <!-- 將大頭貼設置為網頁標籤圖示 -->
+    <link rel="icon" type="image/jpeg" href="{{ "/ChiYu-Blob/images/avatar.jpg" | relURL }}">
+
     {{ $customCSS := resources.Get "css/custom.css" | minify }}
     <link rel="stylesheet" href="{{ $customCSS.Permalink }}">
 


### PR DESCRIPTION
## Summary
- set profile avatar as the favicon in the site header

## Testing
- `go test ./...` *(returns "no packages to test")*
- `hugo -D` *(fails: `hugo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68479101af5c8321b6e65c9abfd07a85