### PR TITLE
調整標題字體與修復深色模式 Hover 效果

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -53,6 +53,8 @@
     align-items: center;
 }
 
+
+
 /* 限制預覽圖外層容器的寬度，並增加右邊距 */
 .pagefind-ui__result-thumb {
     flex-shrink: 0;
@@ -77,4 +79,10 @@
     margin-bottom: 2em;      /* 圖片與下方文字的距離 */
     border-radius: 0.75rem;  /* 加上圓角，與網站整體風格搭配 (12px) */
     border: 1px solid var(--border-color); /* 加上符合主題顏色的邊框 */
+}
+
+/* --- 修復：上下篇文章切換按鈕的 Hover 效果 --- */
+nav.not-prose a:hover {
+    background-color: var(--border-color);
+    opacity: 0.8;
 }

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -5,12 +5,15 @@
             <section class="mb-12 sm:mb-16">
                 <header class="border-b pb-6 mb-6" style="border-color: var(--border-color);">
                     {{ if .IsSection }}
-                        <h1 class="text-3xl sm:text-5xl font-bold tracking-tight">{{ .Title }}</h1>
+                        <!-- 調整標題字體大小 -->
+                        <h1 class="text-2xl sm:text-4xl font-bold tracking-tight">{{ .Title }}</h1>
                     {{ else if eq .Kind "term" }}
                         <p class="text-lg" style="color: var(--text-secondary);">{{ .Data.Singular | title }}</p>
-                        <h1 class="text-3xl sm:text-5xl font-bold tracking-tight mt-1">{{ .Title }}</h1>
+                        <!-- 調整標題字體大小 -->
+                        <h1 class="text-2xl sm:text-4xl font-bold tracking-tight mt-1">{{ .Title }}</h1>
                     {{ else }}
-                        <h1 class="text-3xl sm:text-5xl font-bold tracking-tight">{{ .Title }}</h1>
+                        <!-- 調整標題字體大小 -->
+                        <h1 class="text-2xl sm:text-4xl font-bold tracking-tight">{{ .Title }}</h1>
                     {{ end }}
                 </header>
             </section>

--- a/layouts/partials/content-body.html
+++ b/layouts/partials/content-body.html
@@ -1,6 +1,7 @@
 <article class="prose max-w-none">
     <header class="mb-8">
-        <h1 class="text-3xl sm:text-5xl font-bold tracking-tight mb-4 !mt-0">{{ .Title }}</h1>
+        <!-- 調整標題字體大小，讓版面更協調 -->
+        <h1 class="text-2xl sm:text-4xl font-bold tracking-tight mb-4 !mt-0">{{ .Title }}</h1>
         {{ if eq .Type "posts" }}
         <p class="text-base" style="color: var(--text-secondary);">
             發布於 {{ .Date.Format "2006年1月2日" }}
@@ -44,7 +45,8 @@
         {{ end }}
 
         {{ with $prev }}
-            <a href="{{ .Permalink }}" class="block p-4 rounded-lg transition-colors hover:bg-gray-100 dark:hover:bg-gray-800" style="color: var(--text-secondary);">
+            <!-- 移除 hover 背景色，改由 CSS 控制 -->
+            <a href="{{ .Permalink }}" class="block p-4 rounded-lg transition-colors" style="color: var(--text-secondary);">
                 <span class="text-sm">上一篇</span>
                 <span class="block font-semibold mt-1" style="color: var(--text-color);">{{ .Title }} &rarr;</span>
             </a>
@@ -62,7 +64,8 @@
         {{ end }}
 
         {{ with $next }}
-            <a href="{{ .Permalink }}" class="block p-4 rounded-lg transition-colors hover:bg-gray-100 dark:hover:bg-gray-800" style="color: var(--text-secondary);">
+            <!-- 移除 hover 背景色，改由 CSS 控制 -->
+            <a href="{{ .Permalink }}" class="block p-4 rounded-lg transition-colors" style="color: var(--text-secondary);">
                 <span class="text-sm">下一篇</span>
                 <span class="block font-semibold mt-1" style="color: var(--text-color);">&larr; {{ .Title }}</span>
             </a>


### PR DESCRIPTION
## Summary
- 調整文章與列表頁標題字體大小
- 深色模式下移除連結 hover 白底並新增統一樣式

## Testing
- `hugo --minify --gc --baseURL "/ChiYu-Blob/"`
- `htmltest -c .htmltest.yml ./public`


------
https://chatgpt.com/codex/tasks/task_e_6849273a50e88321ba720e48742f2fba