### PR TITLE
Fix nav slugs after renaming posts

### DIFF
--- a/content/posts/2025/06/codex-intro.md
+++ b/content/posts/2025/06/codex-intro.md
@@ -2,6 +2,7 @@
 title = "第一次認識 Codex：讓 AI 幫你寫程式不是夢！"
 date = 2025-06-05
 tags = ["AI", "Codex"]
+next_post_slug = "develop-blob-with-codex"
 +++
 
 最近如果你有在關注 AI 或寫程式的領域，可能會聽過一個名字——Codex。它是 OpenAI 推出的一個超厲害工具，簡單來說，就是一個會寫程式的 AI。今天這篇文章就想用比較輕鬆的方式，來帶大家初步認識一下 Codex 是什麼、可以拿來做什麼、還有怎麼開始玩看看。

--- a/content/posts/2025/06/develop-blob-with-codex.md
+++ b/content/posts/2025/06/develop-blob-with-codex.md
@@ -3,6 +3,7 @@ title = "我是如何使用 AI (Codex) 打造這個 Hugo 部落格的"
 date = 2025-06-08
 tags = [ "AI"]
 description = "一篇實戰紀錄，分享我如何利用 AI 程式助理 Codex (整合於 ChatGPT) 從零到一開發這個 Hugo 靜態網站，從前端互動功能到後端自動化部署的完整過程。"
+prev_post_slug = "codex-intro"
 +++
 
 在上一篇文章 [《第一次認識 Codex：讓 AI 幫你寫程式不是夢！》](/ChiYu-Blob/posts/codex-intro/) 中，我介紹了 Codex 這個強大的 AI 程式助理。而今天，我想分享一個更具體的實戰經驗：我是如何利用 Codex 來開發**你現在正在看的這個部落格**。

--- a/content/posts/2025/06/hugo-blob-template-intro.md
+++ b/content/posts/2025/06/hugo-blob-template-intro.md
@@ -3,6 +3,7 @@ title = "想快速打造個人部落格？試試 HugoBlobTemplate，極簡、開
 date = 2025-06-11
 tags = ["Hugo"]
 description = "一篇專案介紹文，分享如何使用 HugoBlobTemplate 這個開源、極簡的靜態網站模板，快速、幾乎零成本地建立一個屬於自己的個人部落格，讓你專注於內容創作。"
+next_post_slug = "hugo-customization-guide"
 +++
 
 -----

--- a/content/posts/2025/06/hugo-customization-guide.md
+++ b/content/posts/2025/06/hugo-customization-guide.md
@@ -3,6 +3,7 @@ title = "讓部落格成為你的形狀：Hugo 個人化設定終極指南"
 date = 2025-06-11
 tags = ["Hugo"]
 description = "一份終極指南，教你如何將 HugoBlobTemplate 或 ChiYu-Blob 專案，從裡到外徹底改造成專屬於你的個人網站。內容涵蓋核心資訊設定、Giscus 留言系統、大頭貼更換、多種 CSS 配色範本、字型更換教學，以及所有個人化細節。"
+prev_post_slug = "hugo-blob-template-intro"
 +++
 -----
 


### PR DESCRIPTION
## Summary
- add `prev_post_slug` and `next_post_slug` to maintain manual navigation links after renaming posts

## Testing
- `hugo --minify --gc --baseURL "/ChiYu-Blob/"`
- `htmltest -c .htmltest.yml ./public`


------
https://chatgpt.com/codex/tasks/task_e_68492ff5f6348321b933a822800abf7c