### PR TITLE
修正上一篇與下一篇文章查找邏輯

### DIFF
--- a/layouts/partials/content-body.html
+++ b/layouts/partials/content-body.html
@@ -35,17 +35,22 @@
     {{/* ---------- 上一篇文章 ---------- */}}
     <div>
         {{ $prev := "" }}
-        {{/* 若 front matter 有設定 prev_post_slug，優先以此為主 */}}
+        {{/* 優先使用 front matter 中指定的 prev_post_slug */}}
         {{ with .Params.prev_post_slug }}
-            {{ $prev = $.Site.GetPage (printf "posts/%s" .) }}
+            {{ $slug := . }}
+            {{/* 透過檔名 (File.ContentBaseName) 找到對應頁面 */}}
+            {{ $found := where $.Site.RegularPages "File.ContentBaseName" $slug }}
+            {{ if $found }}
+                {{ $prev = index $found 0 }}
+            {{ end }}
         {{ end }}
-        {{/* 若未手動指定，則退回預設依日期排序的 PrevInSection */}}
+
+        {{/* 若未手動指定，則退回預設排序的 PrevInSection */}}
         {{ if not $prev }}
             {{ $prev = .PrevInSection }}
         {{ end }}
 
         {{ with $prev }}
-            <!-- 移除 hover 背景色，改由 CSS 控制 -->
             <a href="{{ .Permalink }}" class="block p-4 rounded-lg transition-colors" style="color: var(--text-secondary);">
                 <span class="text-sm">上一篇</span>
                 <span class="block font-semibold mt-1" style="color: var(--text-color);">{{ .Title }} &rarr;</span>
@@ -56,15 +61,22 @@
     {{/* ---------- 下一篇文章 ---------- */}}
     <div class="text-right">
         {{ $next := "" }}
+        {{/* 優先使用 front matter 中指定的 next_post_slug */}}
         {{ with .Params.next_post_slug }}
-            {{ $next = $.Site.GetPage (printf "posts/%s" .) }}
+            {{ $slug := . }}
+            {{/* 透過檔名 (File.ContentBaseName) 找到對應頁面 */}}
+            {{ $found := where $.Site.RegularPages "File.ContentBaseName" $slug }}
+            {{ if $found }}
+                {{ $next = index $found 0 }}
+            {{ end }}
         {{ end }}
+
+        {{/* 若未手動指定，則退回預設排序的 NextInSection */}}
         {{ if not $next }}
             {{ $next = .NextInSection }}
         {{ end }}
 
         {{ with $next }}
-            <!-- 移除 hover 背景色，改由 CSS 控制 -->
             <a href="{{ .Permalink }}" class="block p-4 rounded-lg transition-colors" style="color: var(--text-secondary);">
                 <span class="text-sm">下一篇</span>
                 <span class="block font-semibold mt-1" style="color: var(--text-color);">&larr; {{ .Title }}</span>


### PR DESCRIPTION
## Summary
- 改善 `content-body.html` 中的文章導覽邏輯，能依 `prev_post_slug` 與 `next_post_slug` 精準找到文章
- 加入詳細繁體中文註解

## Testing
- `apt-get update`
- `apt-get install -y hugo`
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_6849321a82348321b2df4174b1115341