### PR TITLE
修正文章排序與導覽列

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -47,7 +47,11 @@
             <a href="/ChiYu-Blob/" class="text-xl sm:text-2xl font-bold" style="color: var(--text-color);">{{ .Site.Title }}</a>
             <nav class="flex items-center space-x-2 sm:space-x-4">
                 <div id="search" ></div>
-                <a href="/ChiYu-Blob/about/" class="text-sm sm:text-base" style="color: var(--text-secondary);">關於我</a>
+                {{/* --- ↓↓↓ 讀取 hugo.toml 的主選單項目 ↓↓↓ --- */}}
+                {{ range .Site.Menus.main }}
+                <a href="{{ .URL }}" class="text-sm sm:text-base" style="color: var(--text-secondary);">{{ .Name }}</a>
+                {{ end }}
+                {{/* --- ↑↑↑ 讀取 hugo.toml 的主選單項目 ↑↑↑ --- */}}
                 <button id="theme-toggle" title="切換深色/淺色主題">
                     <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
                     <svg class="moon-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,11 +13,16 @@
                 <h2 class="text-2xl sm:text-3xl font-bold mb-6 sm:mb-8 border-b pb-3" style="border-color: var(--border-color);">最新文章</h2>
 
                 <div class="space-y-8">
-                    {{/* 先依日期排序，相同日期再依權重排序 */}}
-                    {{ $sorted := sort .Site.RegularPages "Date" "desc" "Weight" "desc" }}
+                    {{/* --- ↓↓↓ 依日期與權重排序最新文章 ↓↓↓ --- */}}
+                    {{/* 1. 僅從 "posts" 類型篩選文章 */}}
+                    {{ $pages := where .Site.RegularPages "Type" "posts" }}
+                    {{/* 2. 先依日期降冪，再依權重降冪排序 */}}
+                    {{ $sorted := sort $pages "Date" "desc" "Weight" "desc" }}
+                    {{/* 3. 取出最新五篇文章 */}}
                     {{ range first 5 $sorted }}
                         {{ .Render "card" }}
                     {{ end }}
+                    {{/* --- ↑↑↑ 依日期與權重排序最新文章 ↑↑↑ --- */}}
                 </div>
             </section>
         </main>

--- a/layouts/posts/list.html
+++ b/layouts/posts/list.html
@@ -10,12 +10,19 @@
 
             <section>
                 <div class="space-y-8">
-                    {{/* 依日期排序，相同日期再依權重排序 */}}
-                    {{ range sort .Pages "Date" "desc" "Weight" "desc" }}
+                    {{/* --- ↓↓↓ 建立分頁並依日期與權重排序 ↓↓↓ --- */}}
+                    {{/* 1. 建立分頁器：先依日期降序，再依權重降序 */}}
+                    {{ $paginator := .Paginate (sort .Pages "Date" "desc" "Weight" "desc") }}
+                    {{/* 2. 輸出當前分頁的文章 */}}
+                    {{ range $paginator.Pages }}
                         {{ .Render "card" }}
                     {{ end }}
+                    {{/* --- ↑↑↑ 建立分頁並依日期與權重排序 ↑↑↑ --- */}}
                 </div>
             </section>
+
+            {{/* 新增分頁導覽列 */}}
+            {{ partial "pagination.html" . }}
         </main>
     </div>
     {{ partial "tag_sidebar.html" . }}


### PR DESCRIPTION
## Summary
- 調整首頁文章排序邏輯，僅顯示 `posts` 並依 `日期 > 權重` 排序
- 文章列表頁新增 Hugo 分頁功能並套用同樣排序規則
- 導覽列改為讀取 `hugo.toml` 的 `main` 選單

## Testing
- `hugo --minify --gc --baseURL "/ChiYu-Blob/"`
- `htmltest -c .htmltest.yml ./public`

------
https://chatgpt.com/codex/tasks/task_e_684a4b117d9083219613ba4879461305