### PR TITLE
Add series taxonomy and series navigation

### DIFF
--- a/content/posts/2025/06/0005design-pattern-intro.md
+++ b/content/posts/2025/06/0005design-pattern-intro.md
@@ -4,7 +4,8 @@ date = 2025-06-11T12:00:00+08:00
 tags = ["Code", "C#", "DesignPattern"]
 prev_post_slug = "0004hugo-customization-guide"
 next_post_slug = "0006singleton-pattern"
-weight = 5
+series = ["設計模式"]
+weight = 1
 +++
 
 

--- a/content/posts/2025/06/0006singleton-pattern.md
+++ b/content/posts/2025/06/0006singleton-pattern.md
@@ -4,7 +4,8 @@ date = 2025-06-12T10:00:00+08:00
 tags = ["Code", "C#", "DesignPattern"]
 prev_post_slug = "0005design-pattern-intro"
 next_post_slug = "0007abstract-factory-pattern"
-weight = 6
+series = ["設計模式"]
+weight = 2
 +++
 
 在上一篇文章中，我們簡單認識了什麼是「設計模式」。這次，就讓我們從最經典的「單例模式（Singleton）」開始，看看它究竟能為開發帶來什麼幫助吧！

--- a/content/posts/2025/06/0007abstract-factory-pattern.md
+++ b/content/posts/2025/06/0007abstract-factory-pattern.md
@@ -4,7 +4,8 @@ date = 2025-06-12T11:00:00+08:00
 tags = ["Code", "C#", "DesignPattern"]
 prev_post_slug = "0006singleton-pattern"
 next_post_slug = "0008prototype-pattern"
-weight = 7
+series = ["設計模式"]
+weight = 3
 +++
 嗨各位朋友～前面我們介紹過了 Singleton 和 Factory Method，今天要繼續往下走，聊一個稍微進階一點點的設計模式：「抽象工廠模式（Abstract Factory）」。
 

--- a/content/posts/2025/06/0008prototype-pattern.md
+++ b/content/posts/2025/06/0008prototype-pattern.md
@@ -4,7 +4,8 @@ date = 2025-06-12T12:00:00+08:00
 tags = ["Code", "C#", "DesignPattern"]
 prev_post_slug = "0007abstract-factory-pattern"
 next_post_slug = "0009builder-pattern"
-weight = 8
+series = ["設計模式"]
+weight = 4
 +++
 
 嗨！繼續設計模式系列，這次要介紹的主角是**原型模式（Prototype）**。聽到「原型」這個詞是不是有點不太確定這到底是什麼？別擔心，我們還是用輕鬆易懂的方式來理解它吧！

--- a/content/posts/2025/06/0009builder-pattern.md
+++ b/content/posts/2025/06/0009builder-pattern.md
@@ -4,7 +4,8 @@ date = 2025-06-12T13:00:00+08:00
 tags = ["Code", "C#", "DesignPattern"]
 prev_post_slug = "0008prototype-pattern"
 next_post_slug = "0010adapter-pattern"
-weight = 9
+series = ["設計模式"]
+weight = 5
 +++
 
 哈囉各位朋友們～今天我們繼續設計模式之旅，來聊聊 **建造者模式（Builder）** 吧！

--- a/content/posts/2025/06/0010adapter-pattern.md
+++ b/content/posts/2025/06/0010adapter-pattern.md
@@ -4,7 +4,8 @@ date = 2025-06-12T14:00:00+08:00
 tags = ["Code", "C#", "DesignPattern"]
 prev_post_slug = "0009builder-pattern"
 next_post_slug = "0011bridge-pattern"
-weight = 10
+series = ["設計模式"]
+weight = 6
 +++
 
 哈囉大家！今天我們要介紹的設計模式是：**介面卡模式（Adapter）**，又叫做轉接器模式。

--- a/content/posts/2025/06/0011bridge-pattern.md
+++ b/content/posts/2025/06/0011bridge-pattern.md
@@ -4,7 +4,8 @@ date = 2025-06-12T15:00:00+08:00
 tags = ["Code", "C#", "DesignPattern"]
 prev_post_slug = "0010adapter-pattern"
 next_post_slug = "0012composite-pattern"
-weight = 11
+series = ["設計模式"]
+weight = 7
 +++
 
 哈囉大家～我們繼續來探索設計模式的世界吧！今天要介紹的是一個聽起來可能有點陌生，但其實很實用的設計模式：**橋接模式（Bridge）**。

--- a/content/posts/2025/06/0012composite-pattern.md
+++ b/content/posts/2025/06/0012composite-pattern.md
@@ -3,7 +3,8 @@ title = "組合模式：樹狀結構的好幫手"
 date = 2025-06-12T16:00:00+08:00
 tags = ["Code", "C#", "DesignPattern"]
 prev_post_slug = "0011bridge-pattern"
-weight = 12
+series = ["設計模式"]
+weight = 8
 +++
 
 哈囉大家，歡迎繼續探索設計模式之旅！今天要介紹的是一個既實用又好理解的設計模式：**組合模式（Composite）**。

--- a/hugo.toml
+++ b/hugo.toml
@@ -7,6 +7,7 @@ paginate = 5
 [taxonomies]
   tag = "tags"
   category = "categories"
+  series = "series"
 
 [related]
   threshold = 80

--- a/layouts/partials/content-body.html
+++ b/layouts/partials/content-body.html
@@ -29,6 +29,7 @@
     </div>
 
 </article>
+{{ partial "series-box.html" . }}
 
 {{/* --- ↓↓↓ 更新區塊：支援手動與自動的上下篇導覽 ↓↓↓ --- */}}
 <nav class="flex justify-between mt-16 pt-8 border-t not-prose" style="border-color: var(--border-color);">

--- a/layouts/partials/series-box.html
+++ b/layouts/partials/series-box.html
@@ -1,0 +1,20 @@
+{{/* 檢查此文章是否有設定 series */}}
+{{ with .Params.series }}
+  {{ $seriesName := index . 0 }}
+  {{ $seriesPage := $.Site.GetPage (printf "/series/%s" ($seriesName | urlize)) }}
+
+  <div class="not-prose mt-16 pt-8 border-t" style="border-color: var(--border-color);">
+    <h3 class="text-xl font-bold mb-4">系列文章：<a href="{{ $seriesPage.Permalink }}" class="text-inherit hover:underline">{{ $seriesName }}</a></h3>
+    <ol class="list-decimal list-inside space-y-2">
+      {{/* 根據權重 (weight) 排序系列文章 */}}
+      {{ range $seriesPage.Pages.ByWeight }}
+        <li class="{{ if eq .Permalink $.Permalink }}font-bold{{ end }}" style="color: var(--text-secondary);">
+          <a href="{{ .Permalink }}" class="{{ if eq .Permalink $.Permalink }}font-bold{{ end }}" style="color: {{ if eq .Permalink $.Permalink }}var(--text-color){{ else }}var(--text-secondary){{ end }};">
+            {{ .Title }}
+            {{ if eq .Permalink $.Permalink }}<span class="text-sm ml-1" style="color: var(--link-color);"> (目前文章)</span>{{ end }}
+          </a>
+        </li>
+      {{ end }}
+    </ol>
+  </div>
+{{ end }}

--- a/layouts/series/list.html
+++ b/layouts/series/list.html
@@ -1,0 +1,23 @@
+{{ define "main" }}
+<div class="flex flex-row justify-center py-8">
+    <div class="w-full max-w-4xl min-w-0">
+        <main>
+            <section class="mb-12 sm:mb-16">
+                <header class="border-b pb-6 mb-6" style="border-color: var(--border-color);">
+                    <p class="text-lg" style="color: var(--text-secondary);">系列文章</p>
+                    <h1 class="text-2xl sm:text-4xl font-bold tracking-tight mt-1">{{ .Title }}</h1>
+                </header>
+            </section>
+
+            <section>
+                <div class="space-y-8">
+                    {{ range .Pages.ByWeight }}
+                        {{ .Render "card" }}
+                    {{ end }}
+                </div>
+            </section>
+        </main>
+    </div>
+    {{ partial "tag_sidebar.html" . }}
+    </div>
+{{ end }}


### PR DESCRIPTION
## Summary
- create a new `series` taxonomy in `hugo.toml`
- update design pattern posts to include `series` and weights
- show a series list for related posts
- add partial to render series info in posts
- support `/series/<name>/` pages sorted by weight

## Testing
- `hugo --minify --gc --baseURL "/ChiYu-Blob/"`
- `htmltest -c .htmltest.yml ./public`


------
https://chatgpt.com/codex/tasks/task_e_684a691cd82483219d191cd76e959cb6