### PR TITLE
修正未來文章預告邏輯

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -43,26 +43,42 @@
             </section>
             {{/* --- ↑↑↑ 新增區塊：顯示系列文章 ↑↑↑ --- */}}
 
-            {{/* --- ↓↓↓ 新增區塊：顯示未來排程文章 ↓↓↓ --- */}}
-            {{/* 1. 從所有正式頁面中挑出排程日期在未來的文章 */}}
+            {{/* --- ↓↓↓ 更新區塊：僅顯示下一篇即將發布文章 ↓↓↓ --- */}}
+            {{/* 1. 取得排程日期在未來的文章 */}}
             {{ $futurePosts := where .Site.RegularPages "Date.After" now }}
 
-            {{/* 2. 依照日期由近到遠排序，以便即將發布的文章排在前面 */}}
+            {{/* 2. 依照日期升冪排序，最接近現在的排在最前面 */}}
             {{ $sortedFuturePosts := sort $futurePosts "Date" "asc" }}
 
-            {{/* 3. 當未來文章數量大於 0 時，才渲染此區塊 */}}
-            {{ if gt (len $sortedFuturePosts) 0 }}
+            {{/* 3. 只取第一篇作為預告文章 */}}
+            {{ with first 1 $sortedFuturePosts }}
             <section class="mt-16">
-                <h2 class="text-2xl sm:text-3xl font-bold mb-6 sm:mb-8 border-b pb-3" style="border-color: var(--border-color);">未來發布文章</h2>
+                <h2 class="text-2xl sm:text-3xl font-bold mb-6 sm:mb-8 border-b pb-3" style="border-color: var(--border-color);">下一篇文章預告</h2>
                 <div class="space-y-8">
-                    {{/* 4. 逐一渲染每篇未來文章的卡片 */}}
-                    {{ range $sortedFuturePosts }}
-                        {{ .Render "card" }}
+                    {{ range . }}
+                    <article class="p-6 rounded-lg transition-all opacity-75" style="background-color: var(--card-bg); border: 1px solid var(--border-color); cursor: not-allowed;">
+                        <header class="mb-2">
+                            <h3 class="text-xl sm:text-2xl font-bold leading-tight" style="color: var(--text-color);">{{ .Title }}</h3>
+                        </header>
+                        <p class="mb-3 text-base" style="color: var(--text-secondary);">
+                            {{ .Summary | truncate 120 }}
+                        </p>
+                        <footer class="flex items-center justify-between text-sm flex-wrap gap-2" style="color: var(--text-secondary);">
+                            <span>預計 {{ .Date.Format "2006年1月2日" }} 發布</span>
+                            {{ with .Params.tags }}
+                            <div class="flex flex-wrap gap-2">
+                                {{ range . }}
+                                <span class="tag-pill">{{ . }}</span>
+                                {{ end }}
+                            </div>
+                            {{ end }}
+                        </footer>
+                    </article>
                     {{ end }}
                 </div>
             </section>
             {{ end }}
-            {{/* --- ↑↑↑ 新增區塊：顯示未來排程文章 ↑↑↑ --- */}}
+            {{/* --- ↑↑↑ 更新完成：僅顯示下一篇即將發布文章 ↑↑↑ --- */}}
 
             <section class="mt-16">
                 <h2 class="text-2xl sm:text-3xl font-bold mb-6 sm:mb-8 border-b pb-3" style="border-color: var(--border-color);">我的開源專案</h2>


### PR DESCRIPTION
## 變更內容
- 更新 `layouts/index.html`，僅顯示下一篇即將發布的文章並停用點擊
- 將預告區塊加入繁體中文註解，並調整標題

## 測試結果
- `hugo --minify --gc --baseURL "/ChiYu-Blob/"`
- `htmltest -c .htmltest.yml ./public`


------
https://chatgpt.com/codex/tasks/task_e_684aab254d488321bce1cc40d2348ba7