### PR TITLE
修正首頁及列表對未來文章的處理

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -50,7 +50,10 @@
             {{/* --- ↓↓↓ 更新區塊：僅顯示下一篇即將發布文章 ↓↓↓ --- */}}
             {{/* 1. 取得排程日期在未來的文章 */}}
             {{/* 限定類型為 posts，並篩選日期在未來的文章 */}}
-            {{ $futurePosts := where (where .Site.RegularPages "Type" "posts") "Date.After" now }}
+            {{/* --- ↓↓↓ 使用更精確的方式取得 posts 區塊下的未來文章 ↓↓↓ --- */}}
+            {{ $postsSection := .Site.GetPage "posts" }}
+            {{ $futurePosts := where $postsSection.Pages "Date.After" now }}
+            {{/* --- ↑↑↑ 修正結束 ↑↑↑ --- */}}
 
             {{/* 2. 依照日期升冪排序，最接近現在的排在最前面 */}}
             {{ $sortedFuturePosts := sort $futurePosts "Date" "asc" }}

--- a/layouts/partials/calendar.html
+++ b/layouts/partials/calendar.html
@@ -17,7 +17,7 @@
 document.addEventListener('DOMContentLoaded', function() {
     
     const postedDates = {};
-    {{ range where .Site.RegularPages "Type" "posts" }}
+    {{ range where (where .Site.RegularPages "Type" "posts") "Date" "le" now }}
         {{ $dateStr := .Date.Format "2006-1-2" }}
         
         {{/* --- 修正：直接使用文章的永久連結 (.Permalink) --- */}}

--- a/layouts/posts/list.html
+++ b/layouts/posts/list.html
@@ -12,7 +12,8 @@
                 <div class="space-y-8">
                     {{/* --- ↓↓↓ 移除 Weight，僅依日期排序並建立分頁 ↓↓↓ --- */}}
                     {{/* 1. 建立分頁器：僅依日期降冪排序，日期需包含時間 */}}
-                    {{ $paginator := .Paginate (sort .Pages "Date" "desc") }}
+                    {{/* 在排序前過濾掉未來日期的文章 */}}
+                    {{ $paginator := .Paginate (sort (where .Pages "Date" "le" now) "Date" "desc") }}
                     {{/* 2. 輸出當前分頁的文章 */}}
                     {{ range $paginator.Pages }}
                         {{ .Render "card" }}


### PR DESCRIPTION
## Summary
- 嚴格限定從 `posts` 目錄取得未來文章，避免首頁抓取錯誤
- 列表頁在分頁前先排除未來文章
- 月曆元件不再包含未來文章日期

## Testing
- `hugo --minify --gc --buildFuture --baseURL "/ChiYu-Blob/"`
- `htmltest -c .htmltest.yml ./public`


------
https://chatgpt.com/codex/tasks/task_e_684ab6ae074083218748330f84a339fb