### PR TITLE
新增側邊欄區塊與樣式

### DIFF
--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -1,0 +1,46 @@
+/* --- 側邊欄新區塊樣式 --- */
+
+/* 每個小工具區塊的間距 */
+.sidebar .widget {
+    margin-top: 30px;
+    padding-top: 20px;
+    border-top: 1px solid var(--border);
+}
+
+/* 小工具標題 */
+.sidebar .widget-title {
+    font-size: 1.1rem;
+    font-weight: bold;
+    margin-bottom: 10px;
+    color: var(--primary);
+}
+
+/* 列表樣式重置 */
+.sidebar .widget-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+/* 列表項目 */
+.sidebar .widget-list li {
+    margin-bottom: 8px;
+}
+
+/* 列表項目連結 */
+.sidebar .widget-list li a {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    text-decoration: none;
+}
+
+/* 文章計數的樣式 */
+.sidebar .widget-list .posts-count {
+    font-size: 0.8em;
+    background-color: var(--tertiary);
+    color: var(--primary);
+    padding: 2px 6px;
+    border-radius: 4px;
+    margin-left: 8px;
+}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -37,6 +37,9 @@
 
     {{ $customCSS := resources.Get "css/custom.css" | minify }}
     <link rel="stylesheet" href="{{ $customCSS.Permalink }}">
+    {{/* 載入延伸用的自訂樣式 */}}
+    {{ $extendedCSS := resources.Get "css/extended/custom.css" | minify }}
+    <link rel="stylesheet" href="{{ $extendedCSS.Permalink }}">
 
 </head>
 <body class="antialiased">

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,0 +1,42 @@
+{{- $existingContent := .Scratch.Get "sidebar" -}}
+
+{{- if or $existingContent (not .IsHome) -}}
+<aside class="sidebar">
+    <div class="sidebar-inner">
+        {{/* 原本側邊欄的內容，這裡會放置目錄等 */}}
+        {{ $existingContent }}
+
+        {{/* === 新增：系列文章 === */}}
+        {{- with .Site.Taxonomies.series.ByCount -}}
+        <div class="widget">
+            <h3 class="widget-title">系列文章</h3>
+            <ul class="widget-list">
+                {{- range . -}}
+                <li>
+                    <a href="{{ .Page.Permalink }}">
+                        {{ .Page.Title }}
+                        <span class="posts-count">{{ .Count }}</span>
+                    </a>
+                </li>
+                {{- end -}}
+            </ul>
+        </div>
+        {{- end -}}
+        
+        {{/* === 新增：開源專案 === */}}
+        {{- $pages := where site.RegularPages "Type" "in" "projects" -}}
+        {{- if $pages -}}
+        <div class="widget">
+            <h3 class="widget-title">開源專案</h3>
+            <ul class="widget-list">
+                {{- range $pages -}}
+                <li>
+                    <a href="{{ .Permalink }}">{{ .Title }}</a>
+                </li>
+                {{- end -}}
+            </ul>
+        </div>
+        {{- end -}}
+    </div>
+</aside>
+{{- end -}}

--- a/layouts/partials/tag_sidebar.html
+++ b/layouts/partials/tag_sidebar.html
@@ -33,6 +33,38 @@
         </div>
         {{ end }}
 
-       
+        {{/* --- 新增：系列文章列表 --- */}}
+        {{ with .Site.Taxonomies.series.ByCount }}
+        <div class="mt-8">
+            <h3 class="text-xl font-bold mb-4 pb-2 border-b" style="border-color: var(--border-color);">系列文章</h3>
+            <ul class="space-y-1">
+                {{ range . }}
+                <li>
+                    <a href="{{ .Page.Permalink }}" class="flex justify-between">
+                        <span>{{ .Page.Title }}</span>
+                        <span class="text-sm">{{ .Count }}</span>
+                    </a>
+                </li>
+                {{ end }}
+            </ul>
+        </div>
+        {{ end }}
+
+        {{/* --- 新增：開源專案列表 --- */}}
+        {{ $projects := where site.RegularPages "Type" "in" "projects" }}
+        {{ if $projects }}
+        <div class="mt-8">
+            <h3 class="text-xl font-bold mb-4 pb-2 border-b" style="border-color: var(--border-color);">開源專案</h3>
+            <ul class="space-y-1">
+                {{ range $projects }}
+                <li>
+                    <a href="{{ .Permalink }}">{{ .Title }}</a>
+                </li>
+                {{ end }}
+            </ul>
+        </div>
+        {{ end }}
+
+
     </div>
 </aside>


### PR DESCRIPTION
## Summary
- 新增 `layouts/partials/sidebar.html`，讓系列文章與開源專案能出現在側邊欄
- `tag_sidebar.html` 同步加入系列文章及開源專案區塊
- 在 `baseof.html` 載入 `assets/css/extended/custom.css`
- 新增對應的自訂樣式

## Testing
- `hugo --minify --gc --baseURL "/ChiYu-Blob/"`
- `htmltest -c .htmltest.yml ./public`


------
https://chatgpt.com/codex/tasks/task_e_684b797071d88321bf29fcc156b9774a